### PR TITLE
feat: reply/2 instead of deprecated assign_data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ npm-debug.log
 # Ignore Elixir_ls extension folder
 .elixir_ls
 
+.DS_Store

--- a/lib/lenra_common_web/controllers/controller_helpers.ex
+++ b/lib/lenra_common_web/controllers/controller_helpers.ex
@@ -50,6 +50,7 @@ defmodule LenraCommonWeb.ControllerHelpers do
     Plug.Conn.assign(conn, :error, error)
   end
 
+  @deprecated "Use reply/2 directly instead"
   def assign_data(%Plug.Conn{} = conn, value) do
     Plug.Conn.assign(conn, :data, value)
   end
@@ -60,5 +61,11 @@ defmodule LenraCommonWeb.ControllerHelpers do
 
   def reply(%Plug.Conn{} = conn) do
     Phoenix.Controller.render(conn, "success.json")
+  end
+
+  def reply(%Plug.Conn{} = conn, data) do
+    conn
+    |> Plug.Conn.assign(:root, data)
+    |> Phoenix.Controller.render("success.json")
   end
 end

--- a/lib/lenra_common_web/views/base_view.ex
+++ b/lib/lenra_common_web/views/base_view.ex
@@ -8,6 +8,10 @@ defmodule LenraCommonWeb.BaseView do
     }
   end
 
+  def render("success.json", %{root: data}) do
+    data
+  end
+
   def render("success.json", _no_data) do
     %{}
   end


### PR DESCRIPTION
## Checklist
- [x] I didn't over-scope my PR
- [x] My PR title matches the [commit convention](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I did not include breaking changes
- [ ] I included unit tests that cover my changes
- [ ] I added/updated the documentation about my changes
- [x] I made my own code-review before requesting one

## Description of the changes
To push the new standard. Remove the "data" key to api response.
```json
{
  "id": 42,
  "name": "truc"
}
```

Instead of
```json
{
  "data": {
    "id": 42,
    "name": "truc"
  }
}
```

## Technical highlight/advice
the old assign_data is deprecated.