### PR TITLE
feat: add default and customisable status_code error on structs

### DIFF
--- a/lib/lenra_common/errors/business_error.ex
+++ b/lib/lenra_common/errors/business_error.ex
@@ -7,7 +7,7 @@ defmodule LenraCommon.Errors.BusinessError do
   """
   @errors [
     {:forbidden, "Forbidden", 403},
-    {:unauthorized, "Forbidden", 401},
+    {:unauthorized, "Unauthorized", 401},
     {:nil_json, "JsonHelper cannot get in nil json."},
     {:integer_array_index, "You need to specify an integer to get an element of an array."}
   ]

--- a/lib/lenra_common/errors/business_error.ex
+++ b/lib/lenra_common/errors/business_error.ex
@@ -6,12 +6,13 @@ defmodule LenraCommon.Errors.BusinessError do
     the second that creates a BusinessError struct and returns it into a tuple.
   """
   @errors [
-    {:forbidden, "Forbidden"},
+    {:forbidden, "Forbidden", 403},
+    {:unauthorized, "Forbidden", 401},
     {:nil_json, "JsonHelper cannot get in nil json."},
     {:integer_array_index, "You need to specify an integer to get an element of an array."}
   ]
 
-  use LenraCommon.Errors.ErrorStruct
+  use LenraCommon.Errors.ErrorStruct, default_status_code: 400
   use LenraCommon.Errors.ErrorGenerator, errors: @errors, module: __MODULE__
 
   def __errors__ do

--- a/lib/lenra_common/errors/business_error.ex
+++ b/lib/lenra_common/errors/business_error.ex
@@ -13,7 +13,7 @@ defmodule LenraCommon.Errors.BusinessError do
   ]
 
   use LenraCommon.Errors.ErrorStruct, default_status_code: 400
-  use LenraCommon.Errors.ErrorGenerator, errors: @errors, module: __MODULE__
+  use LenraCommon.Errors.ErrorGenerator, errors: @errors
 
   def __errors__ do
     @errors

--- a/lib/lenra_common/errors/dev_error.ex
+++ b/lib/lenra_common/errors/dev_error.ex
@@ -6,7 +6,7 @@ defmodule LenraCommon.Errors.DevError do
   """
   @errors []
 
-  use LenraCommon.Errors.ErrorStruct
+  use LenraCommon.Errors.ErrorStruct, default_status_code: 400
   use LenraCommon.Errors.ErrorGenerator, errors: @errors, module: __MODULE__
 
   def __errors__ do

--- a/lib/lenra_common/errors/dev_error.ex
+++ b/lib/lenra_common/errors/dev_error.ex
@@ -7,7 +7,7 @@ defmodule LenraCommon.Errors.DevError do
   @errors []
 
   use LenraCommon.Errors.ErrorStruct, default_status_code: 400
-  use LenraCommon.Errors.ErrorGenerator, errors: @errors, module: __MODULE__
+  use LenraCommon.Errors.ErrorGenerator, errors: @errors
 
   def __errors__ do
     @errors

--- a/lib/lenra_common/errors/error_generator.ex
+++ b/lib/lenra_common/errors/error_generator.ex
@@ -55,20 +55,21 @@ defmodule LenraCommon.Errors.ErrorGenerator do
     # See https://hexdocs.pm/elixir/Kernel.SpecialForms.html#quote/2-binding-and-unquote-fragments
     # to explain why we use bind_quoted
     quote bind_quoted: [errors: errors, module: module] do
+      alias LenraCommon.Errors.ErrorGenerator
+
       Enum.each(errors, fn err ->
         reason = elem(err, 0)
         fn_tuple = (Atom.to_string(reason) <> "_tuple") |> String.to_atom()
 
-        IO.inspect(err)
         err = Macro.escape(err)
 
         def unquote(reason)(metadata \\ %{}) do
-          LenraCommon.Errors.ErrorGenerator.create_struct(unquote(module), metadata, unquote(err))
+          ErrorGenerator.create_struct(unquote(module), metadata, unquote(err))
         end
 
         def unquote(fn_tuple)(metadata \\ %{}) do
           result =
-            LenraCommon.Errors.ErrorGenerator.create_struct(
+            ErrorGenerator.create_struct(
               unquote(module),
               metadata,
               unquote(err)

--- a/lib/lenra_common/errors/error_generator.ex
+++ b/lib/lenra_common/errors/error_generator.ex
@@ -5,8 +5,8 @@ defmodule LenraCommon.Errors.ErrorGenerator do
   """
   defmacro __using__(opts) do
     errors = Keyword.get(opts, :errors, [])
-    module = __CALLER__.module
     inherit = Keyword.get(opts, :inherit, false)
+    module = __CALLER__.module
 
     quote do
       import LenraCommon.Errors.ErrorGenerator

--- a/lib/lenra_common/errors/error_struct.ex
+++ b/lib/lenra_common/errors/error_struct.ex
@@ -2,17 +2,20 @@ defmodule LenraCommon.Errors.ErrorStruct do
   @moduledoc """
     LenraCommon.Errors.ErrorStruct defines a basic error struct for Lenra server.
   """
-  defmacro __using__(_opts) do
+  defmacro __using__(opts) do
+    default_status_code = Keyword.fetch!(opts, :default_status_code)
+
     quote do
-      @derive {Jason.Encoder, only: [:message, :reason, :metadata]}
+      @derive {Jason.Encoder, only: [:message, :reason, :metadata, :status_code]}
       @type t() :: %__MODULE__{
               message: String.t(),
               reason: atom(),
-              metadata: any()
+              metadata: any(),
+              status_code: integer()
             }
 
       @enforce_keys [:message, :reason]
-      defexception [:message, :reason, :metadata]
+      defexception [:message, :reason, :metadata, status_code: unquote(default_status_code)]
     end
   end
 end

--- a/lib/lenra_common/errors/technical_error.ex
+++ b/lib/lenra_common/errors/technical_error.ex
@@ -12,7 +12,7 @@ defmodule LenraCommon.Errors.TechnicalError do
     {:error_404, "Not Found."},
     {:error_500, "Internal server error."}
   ]
-  use LenraCommon.Errors.ErrorStruct
+  use LenraCommon.Errors.ErrorStruct, default_status_code: 500
   use LenraCommon.Errors.ErrorGenerator, errors: @errors, module: __MODULE__
 
   def __errors__ do

--- a/lib/lenra_common/errors/technical_error.ex
+++ b/lib/lenra_common/errors/technical_error.ex
@@ -8,12 +8,13 @@ defmodule LenraCommon.Errors.TechnicalError do
 
   @errors [
     {:unknown_error, "Unknown error"},
-    {:bad_request, "Server cannot understand or process the request due to a client-side error."},
-    {:error_404, "Not Found."},
-    {:error_500, "Internal server error."}
+    {:bad_request, "Server cannot understand or process the request due to a client-side error.",
+     400},
+    {:error_404, "Not Found.", 404},
+    {:error_500, "Internal server error.", 500}
   ]
   use LenraCommon.Errors.ErrorStruct, default_status_code: 500
-  use LenraCommon.Errors.ErrorGenerator, errors: @errors, module: __MODULE__
+  use LenraCommon.Errors.ErrorGenerator, errors: @errors
 
   def __errors__ do
     @errors

--- a/lib/lenra_common_web/controllers/controller_helpers.ex
+++ b/lib/lenra_common_web/controllers/controller_helpers.ex
@@ -24,19 +24,10 @@ defmodule LenraCommonWeb.ControllerHelpers do
         |> Plug.Conn.put_status(403)
         |> add_error(BusinessError.forbidden())
 
-      %LenraCommon.Errors.BusinessError{} ->
+      # Should match Business, Technical & Dev errors.
+      %_{status_code: code} ->
         conn
-        |> Plug.Conn.put_status(400)
-        |> add_error(error)
-
-      %LenraCommon.Errors.TechnicalError{} ->
-        conn
-        |> Plug.Conn.put_status(400)
-        |> add_error(error)
-
-      %LenraCommon.Errors.DevError{} ->
-        conn
-        |> Plug.Conn.put_status(400)
+        |> Plug.Conn.put_status(code)
         |> add_error(error)
 
       _error ->


### PR DESCRIPTION
<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📜 Use Conventional Commit for your PR name (see https://www.conventionalcommits.org/en/v1.0.0/).
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->

## Description of the changes
Small change to add status_code to errors (and apply the status code to the returned status).
Best way to implement correct error status code for the OAuth scope system.

- The API stay unchanged.
- When creating a new error, you can add a third element in the tuple : the status code
- This status code is optional and will be applied to the HTTP error returned.
- All The DevErrors & BusinessErrors return a 400 error by default (nothing changed)
- All The TechnicalErrors return a 500 error by default (Changed from 400 to 500)

## Checklist
- [x] I didn't over-scope my PR
- [x] My PR title matches the [commit convention](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I did not include breaking changes
- [x] I made my own code-review before requesting one


### I included unit tests that cover my changes
  - [ ] 👍 yes
  - [ ] 🙅 no, because they aren't needed
  - [ ] 🙋 no, because I need help


### I added/updated the documentation about my changes
- [ ] 📜 README.md
- [ ] 📕 docs/*.md
- [ ] 📓 docs.lenra.io
- [ ] 🙅 no documentation needed

